### PR TITLE
FPSProblemImport bug

### DIFF
--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -678,6 +678,7 @@ class FPSProblemImport(CSRFExemptAPIView):
                     tf.file.write(chunk)
                 tf.file.flush()
                 os.fsync(tf.file)
+                
                 problems = FPSParser(tf.name).parse()
         else:
             return self.error("Parse upload file error")


### PR DESCRIPTION
FPSProblemImport bug
bug：某些fps.xml题目在写入tf时还没写入成功，xml parser就已经通过tf.name读取文件，读取为空文本文件然后导致解析失败，报server error错误。
解决方案：添加tf.file.flush() os.fsync(tf.file) 确保tf文件被成功写入